### PR TITLE
Use different subprocess command for Cython.

### DIFF
--- a/pydy_code_gen/code.py
+++ b/pydy_code_gen/code.py
@@ -257,10 +257,9 @@ class CythonGenerator(object):
         # use.
 
         # This prevents output to stdout and waits till it is done.
-        p = subprocess.Popen(['python', self.setup_py_filename, 'build_ext',
+        p = subprocess.call(['python', self.setup_py_filename, 'build_ext',
                               '--inplace'], stderr=subprocess.STDOUT,
                              stdout=subprocess.PIPE)
-        p.wait()
 
     def generate_extension(self):
         """Generates a Cython extensions module with the given file name


### PR DESCRIPTION
This is the PR requested by @moorepants in issue #11.

Previously, we used a combination of `Popen()` and `wait()` to compile
a Cython file but suppress stdout. On my machine, code continued to
execute despite the call to `wait()`. If I use `call()` instead, the
code waits until the compiling is finished before it proceeds. This is
important for ensuring the tests are executed properly.
